### PR TITLE
Group 8: Added sema integration tests

### DIFF
--- a/src/main/java/com/auberer/compilerdesignlectureproject/sema/TypeChecker.java
+++ b/src/main/java/com/auberer/compilerdesignlectureproject/sema/TypeChecker.java
@@ -64,7 +64,7 @@ public class TypeChecker extends ASTVisitor<ExprResult> {
     for (int i = 1; i < node.operands().size(); i++){
       ExprResult right = visit(node.operands().get(i));
       if (!left.getType().equals(right.getType())){
-        throw new RuntimeException("Type mismatch in logical expression");
+        throw new SemaError(node, "Type mismatch in logical expression");
       }
     }
     Type resultType = left.getType();
@@ -90,7 +90,7 @@ public class TypeChecker extends ASTVisitor<ExprResult> {
     for (int i = 1; i < node.operands().size(); i++){
       ExprResult right = visit(node.operands().get(i));
       if(!left.getType().equals(right.getType())){
-        throw new RuntimeException("Type mismatch in additive expression");
+        throw new SemaError(node, "Type mismatch in additive expression");
       }
     }
     Type resultType = left.getType();
@@ -116,7 +116,7 @@ public class TypeChecker extends ASTVisitor<ExprResult> {
       ExprResult right = visit(node.operands().get(1));
 
       if(!left.getType().equals(right.getType())){
-        throw new RuntimeException("Type mismatch in compare expression");
+        throw new SemaError(node, "Type mismatch in compare expression");
       }
       return new ExprResult(node.setEvaluatedSymbolType(new Type(SuperType.TY_BOOL)));
     }
@@ -162,7 +162,7 @@ public class TypeChecker extends ASTVisitor<ExprResult> {
     for (int i = 1; i < node.operands().size(); i++){
       ExprResult right = visit(node.operands().get(i));
       if(!left.getType().equals(right.getType())){
-        throw new RuntimeException("Type mismatch in multiplicative expression");
+        throw new SemaError(node, "Type mismatch in multiplicative expression");
       }
     }
     Type resultType = left.getType();
@@ -178,7 +178,7 @@ public class TypeChecker extends ASTVisitor<ExprResult> {
         return new ExprResult(node.setEvaluatedSymbolType(resultType));
       }
       else {
-        throw new RuntimeException("Type mismatch in prefix expression");
+        throw new SemaError(node, "Type mismatch in prefix expression");
       }
     }
     return left;

--- a/src/test/java/com/auberer/compilerdesignlectureproject/sema/AdditiveExpressionNodeTest.java
+++ b/src/test/java/com/auberer/compilerdesignlectureproject/sema/AdditiveExpressionNodeTest.java
@@ -1,0 +1,62 @@
+package com.auberer.compilerdesignlectureproject.sema;
+
+import com.auberer.compilerdesignlectureproject.ast.*;
+import com.auberer.compilerdesignlectureproject.lexer.Lexer;
+import com.auberer.compilerdesignlectureproject.parser.Parser;
+import com.auberer.compilerdesignlectureproject.reader.Reader;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AdditiveExpressionNodeTest {
+    @Test
+    @DisplayName("Integration test")
+    void additiveExprIntegrationTest() {
+        String code = """
+                    1 + 2
+                    """;
+        Reader reader = new Reader(code);
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        SymbolTableBuilder symbolTableBuilder = new SymbolTableBuilder();
+
+        ASTAdditiveExprNode astAdditiveExprNode = parser.parseAdditiveExpression();
+        symbolTableBuilder.visitAdditiveExpr(astAdditiveExprNode);
+
+        assertNotNull(astAdditiveExprNode);
+        assertInstanceOf(ASTAdditiveExprNode.class, astAdditiveExprNode);
+        assertEquals(ASTAtomicExprNode.AtomicType.INT_LIT, astAdditiveExprNode.operands().getFirst().operands().getFirst().operand().getExprType());
+        assertEquals(1, astAdditiveExprNode.operands().getFirst().operands().getFirst().operand().getIntLit());
+        assertEquals(ASTAdditiveExprNode.AdditiveOperator.PLUS, astAdditiveExprNode.operatorList.getFirst());
+        assertEquals(ASTAtomicExprNode.AtomicType.INT_LIT, astAdditiveExprNode.operands().getLast().operands().getFirst().operand().getExprType());
+        assertEquals(2, astAdditiveExprNode.operands().getLast().operands().getFirst().operand().getIntLit());
+    }
+
+    @Test
+    @DisplayName("Integration test should throw SemaError with wrong operand type")
+    void additiveExprIntegrationTestWrongType() {
+        String code = """
+                    1 + "a"
+                    """;
+        Reader reader = new Reader(code);
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        SymbolTableBuilder symbolTableBuilder = new SymbolTableBuilder();
+        TypeChecker typeChecker = new TypeChecker();
+
+        ASTAdditiveExprNode astAdditiveExprNode = parser.parseAdditiveExpression();
+        symbolTableBuilder.visitAdditiveExpr(astAdditiveExprNode);
+
+        assertNotNull(astAdditiveExprNode);
+        assertInstanceOf(ASTAdditiveExprNode.class, astAdditiveExprNode);
+        assertEquals(ASTAdditiveExprNode.AdditiveOperator.PLUS, astAdditiveExprNode.operatorList.getFirst());
+
+        SemaError exception = Assertions.assertThrows(SemaError.class, () -> typeChecker.visitAdditiveExpr(astAdditiveExprNode));
+        assertTrue(exception.getMessage().contains("Type mismatch in additive expression"));
+
+    }
+}

--- a/src/test/java/com/auberer/compilerdesignlectureproject/sema/AtomicExpressionNodeTest.java
+++ b/src/test/java/com/auberer/compilerdesignlectureproject/sema/AtomicExpressionNodeTest.java
@@ -1,0 +1,234 @@
+package com.auberer.compilerdesignlectureproject.sema;
+
+import com.auberer.compilerdesignlectureproject.ast.*;
+import com.auberer.compilerdesignlectureproject.lexer.Lexer;
+import com.auberer.compilerdesignlectureproject.parser.Parser;
+import com.auberer.compilerdesignlectureproject.reader.Reader;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class AtomicExpressionNodeTest {
+    @Test
+    public void checkIntResult() {
+        // Create a new Reader object with the given file path
+        Reader reader = new Reader(
+                """
+                        6
+                        """
+                        );
+
+        // Create lexer and parser
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        // Execute parse method
+        ASTAtomicExprNode atomicExprNode = parser.parseAtomicExpression();
+
+        TypeChecker checker = new TypeChecker();
+        ExprResult result = checker.visitAtomicExpr(atomicExprNode);
+
+        assertEquals(SuperType.TY_INT.toString(), result.getType().toString());
+        assertEquals(null, result.getEntry());
+    }
+
+    @Test
+    public void checkDoubleResult() {
+        // Create a new Reader object with the given file path
+        Reader reader = new Reader(
+                """
+                        4.2
+                        """
+        );
+
+        // Create lexer and parser
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        // Execute parse method
+        ASTAtomicExprNode atomicExprNode = parser.parseAtomicExpression();
+
+        TypeChecker checker = new TypeChecker();
+        ExprResult result = checker.visitAtomicExpr(atomicExprNode);
+
+        assertEquals(SuperType.TY_DOUBLE.toString(), result.getType().toString());
+        assertEquals(null, result.getEntry());
+    }
+
+    @Test
+    public void checkStringResult() {
+        // Create a new Reader object with the given file path
+        Reader reader = new Reader(
+                """
+        "XSLT"
+        """);
+
+        // Create lexer and parser
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        // Execute parse method
+        ASTAtomicExprNode atomicExprNode = parser.parseAtomicExpression();
+
+        TypeChecker checker = new TypeChecker();
+        ExprResult result = checker.visitAtomicExpr(atomicExprNode);
+
+        assertEquals(SuperType.TY_STRING.toString(), result.getType().toString());
+        assertEquals(null, result.getEntry());
+    }
+
+    @Test
+    public void checkBoolResult() {
+        // Create a new Reader object with the given file path
+        Reader reader = new Reader(
+                """
+        false
+        """
+        );
+
+        // Create lexer and parser
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        // Execute parse method
+        ASTAtomicExprNode atomicExprNode = parser.parseAtomicExpression();
+
+        TypeChecker checker = new TypeChecker();
+        ExprResult result = checker.visitAtomicExpr(atomicExprNode);
+
+        assertEquals(SuperType.TY_BOOL.toString(), result.getType().toString());
+        assertEquals(null, result.getEntry());
+    }
+
+    @Test
+    public void checkLogicalExprResult() {
+        // Create a new Reader object with the given file path
+        String code = """
+                        a = true;
+                        b = true;
+                     	c = a&&b;
+                    """;
+        Reader reader = new Reader(code);
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        ASTAtomicExprNode astAtomicExprNode = parser.parseAtomicExpression();
+        SymbolTableBuilder symbolTableBuilder = new SymbolTableBuilder();
+
+
+        TypeChecker typeChecker = new TypeChecker();
+
+        // Fake the symbol table entry for a,b,c
+        Scope scope = symbolTableBuilder.getCurrentScopes().peek();
+        symbolTableBuilder.currentScopes.peek().insertSymbol("a", astAtomicExprNode);
+        symbolTableBuilder.currentScopes.peek().insertSymbol("b", astAtomicExprNode);
+        symbolTableBuilder.currentScopes.peek().insertSymbol("c", astAtomicExprNode);
+
+        symbolTableBuilder.visitAtomicExpr(astAtomicExprNode);
+
+        // Set type for a,b,c
+        SymbolTableEntry entryA = scope.lookupSymbolStrict("a", astAtomicExprNode);
+        entryA.updateType(new Type(SuperType.TY_BOOL));
+        SymbolTableEntry entryB = scope.lookupSymbolStrict("b", astAtomicExprNode);
+        entryB.updateType(new Type(SuperType.TY_BOOL));
+        SymbolTableEntry entryC = scope.lookupSymbolStrict("c", astAtomicExprNode);
+        entryC.updateType(new Type(SuperType.TY_BOOL));
+
+        ExprResult result = typeChecker.visitAtomicExpr(astAtomicExprNode);
+        assertTrue(result.getType().is(SuperType.TY_BOOL));
+        assertNotNull(astAtomicExprNode);
+        assertInstanceOf(ASTAtomicExprNode.class, astAtomicExprNode);
+        assertEquals(ASTAtomicExprNode.AtomicType.IDENTIFIER, astAtomicExprNode.getLogicalExpr().operands().getFirst().operands().getFirst().operands().getFirst().operands().getFirst().operand().getExprType());
+        assertEquals("a", astAtomicExprNode.getLogicalExpr().operands().getFirst().operands().getFirst().operands().getFirst().operands().getFirst().operand().getIdentifier());
+        assertEquals(ASTAtomicExprNode.AtomicType.IDENTIFIER, astAtomicExprNode.getLogicalExpr().operands().getLast().operands().getFirst().operands().getFirst().operands().getFirst().operand().getExprType());
+        assertEquals("b", astAtomicExprNode.getLogicalExpr().operands().getFirst().operands().getFirst().operands().getFirst().operands().getFirst().operand().getIdentifier());
+        assertEquals(ASTAtomicExprNode.AtomicType.IDENTIFIER, astAtomicExprNode.getLogicalExpr().operands().getLast().operands().getFirst().operands().getFirst().operands().getFirst().operand().getExprType());
+        assertEquals("c", astAtomicExprNode.getLogicalExpr().operands().getFirst().operands().getFirst().operands().getFirst().operands().getFirst().operand().getIdentifier());
+        assertEquals(ASTLogicalExprNode.LogicalOperator.AND, astAtomicExprNode.getLogicalExpr().operatorList.get(0));
+    }
+
+    @Test
+    public void checkIdentifierResult() {
+        // Create a new Reader object with the given file path
+        String code = """
+                    a=0;
+                    """;
+        Reader reader = new Reader(code);
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        SymbolTableBuilder symbolTableBuilder = new SymbolTableBuilder();
+        ASTAtomicExprNode astAtomicExprNode = parser.parseAtomicExpression();
+
+        Scope scope = symbolTableBuilder.getCurrentScopes().peek();
+        symbolTableBuilder.currentScopes.peek().insertSymbol("a", astAtomicExprNode);
+
+        symbolTableBuilder.visitAtomicExpr(astAtomicExprNode);
+
+        SymbolTableEntry entryA = scope.lookupSymbolStrict("a", astAtomicExprNode);
+        entryA.updateType(new Type(SuperType.TY_INT));
+
+        assertNotNull(astAtomicExprNode);
+        assertInstanceOf(ASTAtomicExprNode.class, astAtomicExprNode);
+    }
+
+    @Test
+    public void checkFunctionCallResult() {
+        // Create a new Reader object with the given file path
+        String code = """
+                    counter.getNumber()
+                    """;
+        Reader reader = new Reader(code);
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        SymbolTableBuilder symbolTableBuilder = new SymbolTableBuilder();
+        ASTAtomicExprNode astAtomicExprNode = parser.parseAtomicExpression();
+
+        Scope scope = symbolTableBuilder.getCurrentScopes().peek();
+        symbolTableBuilder.currentScopes.peek().insertSymbol("counter", astAtomicExprNode);
+        symbolTableBuilder.currentScopes.peek().insertSymbol("getNumber()", astAtomicExprNode);
+
+        symbolTableBuilder.visitAtomicExpr(astAtomicExprNode);
+
+        SymbolTableEntry entryIdentifier = scope.lookupSymbolStrict("counter", astAtomicExprNode);
+        entryIdentifier.updateType(new Type(SuperType.TY_INVALID));
+        SymbolTableEntry entryFunction = scope.lookupSymbolStrict("getNumber()", astAtomicExprNode);
+        entryFunction.updateType(new Type(SuperType.TY_FUNCTION));
+
+        assertNotNull(astAtomicExprNode);
+        assertInstanceOf(ASTAtomicExprNode.class, astAtomicExprNode);
+        assertInstanceOf(ASTFctCallNode.class, astAtomicExprNode.getFctCall());
+    }
+
+    @Test
+    public void checkPrintBuiltInCallResult() {
+        // Create a new Reader object with the given file path
+        String code = """
+                    System.Println("Hello World");
+                    """;
+        Reader reader = new Reader(code);
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        SymbolTableBuilder symbolTableBuilder = new SymbolTableBuilder();
+        ASTAtomicExprNode astAtomicExprNode = parser.parseAtomicExpression();
+
+        Scope scope = symbolTableBuilder.getCurrentScopes().peek();
+        symbolTableBuilder.currentScopes.peek().insertSymbol("System", astAtomicExprNode);
+        symbolTableBuilder.currentScopes.peek().insertSymbol("Println()", astAtomicExprNode);
+
+        symbolTableBuilder.visitAtomicExpr(astAtomicExprNode);
+
+        SymbolTableEntry entryIdentifier = scope.lookupSymbolStrict("System", astAtomicExprNode);
+        entryIdentifier.updateType(new Type(SuperType.TY_INVALID));
+        SymbolTableEntry entryFunction = scope.lookupSymbolStrict("Println()", astAtomicExprNode);
+        entryFunction.updateType(new Type(SuperType.TY_FUNCTION));
+
+        assertNotNull(astAtomicExprNode);
+        assertInstanceOf(ASTAtomicExprNode.class, astAtomicExprNode);
+        assertInstanceOf(ASTPrintBuiltinCallNode.class , astAtomicExprNode.getPrintCall());
+    }
+
+}

--- a/src/test/java/com/auberer/compilerdesignlectureproject/sema/CompareExpressionNodeTest.java
+++ b/src/test/java/com/auberer/compilerdesignlectureproject/sema/CompareExpressionNodeTest.java
@@ -1,0 +1,62 @@
+package com.auberer.compilerdesignlectureproject.sema;
+
+import com.auberer.compilerdesignlectureproject.ast.*;
+import com.auberer.compilerdesignlectureproject.lexer.Lexer;
+import com.auberer.compilerdesignlectureproject.parser.Parser;
+import com.auberer.compilerdesignlectureproject.reader.Reader;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CompareExpressionNodeTest {
+    @Test
+    @DisplayName("Integration test")
+    void compareExprIntegrationTest() {
+        String code = """
+                    2 != 3
+                    """;
+        Reader reader = new Reader(code);
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        SymbolTableBuilder symbolTableBuilder = new SymbolTableBuilder();
+
+        ASTCompareExprNode astCompareExprNode = parser.parseCompareExpression();
+        symbolTableBuilder.visitCompareExpr(astCompareExprNode);
+
+        assertNotNull(astCompareExprNode);
+        assertInstanceOf(ASTCompareExprNode.class, astCompareExprNode);
+        assertEquals(ASTAtomicExprNode.AtomicType.INT_LIT, astCompareExprNode.operands().getFirst().operands().getFirst().operands().getFirst().operand().getExprType());
+        assertEquals(2, astCompareExprNode.operands().getFirst().operands().getFirst().operands().getFirst().operand().getIntLit());
+        assertEquals(ASTCompareExprNode.CompareOperator.NOT_EQUAL, astCompareExprNode.operator);
+        assertEquals(ASTAtomicExprNode.AtomicType.INT_LIT, astCompareExprNode.operands().getLast().operands().getFirst().operands().getFirst().operand().getExprType());
+        assertEquals(3, astCompareExprNode.operands().getLast().operands().getFirst().operands().getFirst().operand().getIntLit());
+    }
+
+    @Test
+    @DisplayName("Integration test should throw SemaError with wrong operand type")
+    void compareExprIntegrationTestWrongType() {
+        String code = """
+                    2 != "a"
+                    """;
+        Reader reader = new Reader(code);
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        SymbolTableBuilder symbolTableBuilder = new SymbolTableBuilder();
+        TypeChecker typeChecker = new TypeChecker();
+
+        ASTCompareExprNode astCompareExprNode = parser.parseCompareExpression();
+        symbolTableBuilder.visitCompareExpr(astCompareExprNode);
+
+        assertNotNull(astCompareExprNode);
+        assertInstanceOf(ASTCompareExprNode.class, astCompareExprNode);
+        assertEquals(ASTCompareExprNode.CompareOperator.NOT_EQUAL, astCompareExprNode.operator);
+
+        SemaError exception = Assertions.assertThrows(SemaError.class, () -> typeChecker.visitCompareExpr(astCompareExprNode));
+        assertTrue(exception.getMessage().contains("Type mismatch in compare expression"));
+
+    }
+}

--- a/src/test/java/com/auberer/compilerdesignlectureproject/sema/LogicalExpressionNodeTest.java
+++ b/src/test/java/com/auberer/compilerdesignlectureproject/sema/LogicalExpressionNodeTest.java
@@ -1,0 +1,84 @@
+package com.auberer.compilerdesignlectureproject.sema;
+
+import com.auberer.compilerdesignlectureproject.ast.*;
+import com.auberer.compilerdesignlectureproject.lexer.Lexer;
+import com.auberer.compilerdesignlectureproject.parser.Parser;
+import com.auberer.compilerdesignlectureproject.reader.Reader;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LogicalExpressionNodeTest {
+    @Test
+    @DisplayName("Integration test")
+    void logicalExprIntegrationTest() {
+        String code = """
+                        a = true;
+                        b = true;
+                     	c = a&&b;
+                    """;
+        Reader reader = new Reader(code);
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        ASTLogicalExprNode astLogicalExprNode = parser.parseLogicalExpression();
+
+        SymbolTableBuilder symbolTableBuilder = new SymbolTableBuilder();
+        TypeChecker typeChecker = new TypeChecker();
+
+        // Fake the symbol table entry for a,b,c
+        Scope scope = symbolTableBuilder.getCurrentScopes().peek();
+        symbolTableBuilder.currentScopes.peek().insertSymbol("a", astLogicalExprNode);
+        symbolTableBuilder.currentScopes.peek().insertSymbol("b", astLogicalExprNode);
+        symbolTableBuilder.currentScopes.peek().insertSymbol("c", astLogicalExprNode);
+
+        symbolTableBuilder.visitLogicalExpr(astLogicalExprNode);
+
+        // Set type for a,b,c
+        SymbolTableEntry entryA = scope.lookupSymbolStrict("a", astLogicalExprNode);
+        entryA.updateType(new Type(SuperType.TY_BOOL));
+        SymbolTableEntry entryB = scope.lookupSymbolStrict("b", astLogicalExprNode);
+        entryB.updateType(new Type(SuperType.TY_BOOL));
+        SymbolTableEntry entryC = scope.lookupSymbolStrict("c", astLogicalExprNode);
+        entryC.updateType(new Type(SuperType.TY_BOOL));
+
+        ExprResult result = typeChecker.visitLogicalExpr(astLogicalExprNode);
+        assertTrue(result.getType().is(SuperType.TY_BOOL));
+        assertNotNull(astLogicalExprNode);
+        assertInstanceOf(ASTLogicalExprNode.class, astLogicalExprNode);
+        assertEquals(ASTAtomicExprNode.AtomicType.IDENTIFIER, astLogicalExprNode.operands().getFirst().operands().getFirst().operands().getFirst().operands().getFirst().operand().getExprType());
+        assertEquals("a", astLogicalExprNode.operands().getFirst().operands().getFirst().operands().getFirst().operands().getFirst().operand().getIdentifier());
+        assertEquals(ASTAtomicExprNode.AtomicType.IDENTIFIER, astLogicalExprNode.operands().getLast().operands().getFirst().operands().getFirst().operands().getFirst().operand().getExprType());
+        assertEquals("b", astLogicalExprNode.operands().getFirst().operands().getFirst().operands().getFirst().operands().getFirst().operand().getIdentifier());
+        assertEquals(ASTAtomicExprNode.AtomicType.IDENTIFIER, astLogicalExprNode.operands().getLast().operands().getFirst().operands().getFirst().operands().getFirst().operand().getExprType());
+        assertEquals("c", astLogicalExprNode.operands().getFirst().operands().getFirst().operands().getFirst().operands().getFirst().operand().getIdentifier());
+        assertEquals(ASTLogicalExprNode.LogicalOperator.AND, astLogicalExprNode.operatorList.getFirst());
+    }
+
+    @Test
+    @DisplayName("Integration test should throw SemaError with wrong operand type")
+    void logicalExprIntegrationTestWrongType() {
+        String code = """
+                    9&&false
+                    """;
+        Reader reader = new Reader(code);
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        SymbolTableBuilder symbolTableBuilder = new SymbolTableBuilder();
+        TypeChecker typeChecker = new TypeChecker();
+
+        ASTLogicalExprNode astLogicalExprNode = parser.parseLogicalExpression();
+        symbolTableBuilder.visitLogicalExpr(astLogicalExprNode);
+
+        assertNotNull(astLogicalExprNode);
+        assertInstanceOf(ASTLogicalExprNode.class, astLogicalExprNode);
+        assertEquals(ASTLogicalExprNode.LogicalOperator.AND, astLogicalExprNode.operatorList.getFirst());
+
+        SemaError exception = Assertions.assertThrows(SemaError.class, () -> typeChecker.visitLogicalExpr(astLogicalExprNode));
+        assertTrue(exception.getMessage().contains("Type mismatch in logical expression"));
+
+    }
+}

--- a/src/test/java/com/auberer/compilerdesignlectureproject/sema/MultiplicativeExpressionNodeTest.java
+++ b/src/test/java/com/auberer/compilerdesignlectureproject/sema/MultiplicativeExpressionNodeTest.java
@@ -1,0 +1,64 @@
+package com.auberer.compilerdesignlectureproject.sema;
+
+import com.auberer.compilerdesignlectureproject.ast.*;
+import com.auberer.compilerdesignlectureproject.lexer.Lexer;
+import com.auberer.compilerdesignlectureproject.parser.Parser;
+import com.auberer.compilerdesignlectureproject.reader.Reader;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MultiplicativeExpressionNodeTest {
+    @Test
+    @DisplayName("Integration test")
+    void multiplicativeExprIntegrationTest() {
+        String code = """
+                    2 * 3
+                    """;
+        Reader reader = new Reader(code);
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        SymbolTableBuilder symbolTableBuilder = new SymbolTableBuilder();
+
+        ASTMultiplicativeExprNode astMultiplicativeExprNode = parser.parseMultiplicativeExpression();
+        symbolTableBuilder.visitMultiplicativeExpr(astMultiplicativeExprNode);
+
+
+        assertNotNull(astMultiplicativeExprNode);
+        assertInstanceOf(ASTMultiplicativeExprNode.class, astMultiplicativeExprNode);
+        assertEquals(ASTAtomicExprNode.AtomicType.INT_LIT, astMultiplicativeExprNode.operands().getFirst().operand().getExprType());
+        assertEquals(2, astMultiplicativeExprNode.operands().getFirst().operand().getIntLit());
+        assertEquals(ASTMultiplicativeExprNode.MultiplicativeOperator.MUL, astMultiplicativeExprNode.operatorList.getFirst());
+        assertEquals(ASTAtomicExprNode.AtomicType.INT_LIT, astMultiplicativeExprNode.operands().getLast().operand().getExprType());
+        assertEquals(3, astMultiplicativeExprNode.operands().getLast().operand().getIntLit());
+    }
+
+    @Test
+    @DisplayName("Integration test should throw SemaError with wrong operand type")
+    void multiplicativeExprIntegrationTestWrongType() {
+        String code = """
+                    2 * "a"
+                    """;
+        Reader reader = new Reader(code);
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        SymbolTableBuilder symbolTableBuilder = new SymbolTableBuilder();
+        TypeChecker typeChecker = new TypeChecker();
+
+        ASTMultiplicativeExprNode astMultiplicativeExprNode = parser.parseMultiplicativeExpression();
+        symbolTableBuilder.visitMultiplicativeExpr(astMultiplicativeExprNode);
+
+
+        assertNotNull(astMultiplicativeExprNode);
+        assertInstanceOf(ASTMultiplicativeExprNode.class, astMultiplicativeExprNode);
+        assertEquals(ASTMultiplicativeExprNode.MultiplicativeOperator.MUL, astMultiplicativeExprNode.operatorList.getFirst());
+
+        SemaError exception = Assertions.assertThrows(SemaError.class, () -> typeChecker.visitMultiplicativeExpr(astMultiplicativeExprNode));
+        assertTrue(exception.getMessage().contains("Type mismatch in multiplicative expression"));
+
+    }
+}

--- a/src/test/java/com/auberer/compilerdesignlectureproject/sema/PrefixExpressionNodeTest.java
+++ b/src/test/java/com/auberer/compilerdesignlectureproject/sema/PrefixExpressionNodeTest.java
@@ -1,0 +1,60 @@
+package com.auberer.compilerdesignlectureproject.sema;
+
+import com.auberer.compilerdesignlectureproject.ast.*;
+import com.auberer.compilerdesignlectureproject.lexer.Lexer;
+import com.auberer.compilerdesignlectureproject.parser.Parser;
+import com.auberer.compilerdesignlectureproject.reader.Reader;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PrefixExpressionNodeTest {
+    @Test
+    @DisplayName("Integration test")
+    void prefixExprIntegrationTest() {
+        String code = """
+                    -4
+                    """;
+        Reader reader = new Reader(code);
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        SymbolTableBuilder symbolTableBuilder = new SymbolTableBuilder();
+
+        ASTPrefixExprNode astPrefixExprNode = parser.parsePrefixExpression();
+        symbolTableBuilder.visitPrefixExpr(astPrefixExprNode);
+
+        assertNotNull(astPrefixExprNode);
+        assertInstanceOf(ASTPrefixExprNode.class, astPrefixExprNode);
+        assertEquals(ASTPrefixExprNode.PrefixOperator.MINUS , astPrefixExprNode.operator);
+        assertEquals(ASTAtomicExprNode.AtomicType.INT_LIT, astPrefixExprNode.operand().getExprType());
+        assertEquals(4, astPrefixExprNode.operand().getIntLit());
+    }
+
+    @Test
+    @DisplayName("Integration test should throw SemaError with wrong operand type")
+    void prefixIntegrationTestExceptionWrongType() {
+        String code = """
+                    -false
+                    """;
+        Reader reader = new Reader(code);
+        Lexer lexer = new Lexer(reader, false);
+        Parser parser = new Parser(lexer);
+
+        SymbolTableBuilder symbolTableBuilder = new SymbolTableBuilder();
+        TypeChecker typeChecker = new TypeChecker();
+
+        ASTPrefixExprNode astPrefixExprNode = parser.parsePrefixExpression();
+        symbolTableBuilder.visitPrefixExpr(astPrefixExprNode);
+
+        assertNotNull(astPrefixExprNode);
+        assertInstanceOf(ASTPrefixExprNode.class, astPrefixExprNode);
+        assertEquals(ASTPrefixExprNode.PrefixOperator.MINUS , astPrefixExprNode.operator);
+
+        SemaError exception = Assertions.assertThrows(SemaError.class, () -> typeChecker.visitPrefixExpr(astPrefixExprNode));
+        assertTrue(exception.getMessage().contains("Type mismatch in prefix expression"));
+
+    }
+}


### PR DESCRIPTION
Added sema integration tests for additive, atomic, compare, logical, multiplicative and prefix expression; corrected error type in Type Checker for logical, additive, compare, multiplicative and prefix expression

⚠**Attention:** Still errors ⚠

1. IndexOutOfBounceException in AtomicExpressionNodeTests for checkLogicalExprResult(), checkPrintBuildInCallResult() and checkFunctionCallResult() :
![IndexOutOfBounceException_AtomicExpr_IntegrationTests_sema](https://github.com/marcauberer/compiler-design-lecture-project-TINF22B6/assets/75337582/413d26a0-cf95-45da-bc1e-d30128d3bd23)

2. AssertionError in LogicExpressionNodeTests for Integration Test:
![Assertion_error_LogicalExpr_IntegrationTest_sema](https://github.com/marcauberer/compiler-design-lecture-project-TINF22B6/assets/75337582/260389bc-7524-49dd-8237-e2114c97f2c9)